### PR TITLE
Flatten template

### DIFF
--- a/src/assets/flat.json
+++ b/src/assets/flat.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": 0,
+    "content": {
+      "text": "The study design is always discussed among lab members and local colleagues.",
+      "difficulty": 1
+    }
+  },
+  {
+    "id": 1,
+    "content": {
+      "text": "The design is discussed with other experts on the field using expert consensus method, adversarial collaboration, presubmission inquiry, or registered report.",
+      "difficulty": 2
+    }
+  },
+  {
+    "id": 2,
+    "content": {
+      "title": "Consultation",
+      "description": "Consultation between the team members.",
+      "options": [
+        0,
+        1
+      ]
+    }
+  },
+  {
+    "id": 3,
+    "content": "We don't do that sort of thing here."
+  },
+  {
+    "id": 4,
+    "content": {
+      "text": "Open-Ended Registration",
+      "hint": "Use this one if you are registering a completed project with data or materials.",
+      "difficulty": 0,
+      "selected": true
+    }
+  },
+  {
+    "id": 5,
+    "content": {
+      "text": "OSF Prereg",
+      "hint": "This is our standard, comprehensive, and general purpose preregistration form."
+    }
+  },
+  {
+    "id": 6,
+    "content": {
+      "text": "OSF - \\1",
+      "hint": "The Open Science Framework offers a variety of preregistration options.",
+      "difficulty": 1,
+      "templateOptions": [
+        [
+          4,
+          5
+        ]
+      ]
+    }
+  },
+  {
+    "id": 7,
+    "content": {
+      "text": "AsPredicted.org",
+      "hint": "AsPredicted offers eight simple questions to support quick preregistration.",
+      "difficulty": 0
+    }
+  },
+  {
+    "id": 8,
+    "content": "the lab website"
+  },
+  {
+    "id": 9,
+    "content": {
+      "text": "We publically preregister every project before following \\1 standards. At minimum we preregister using \\2.",
+      "difficulty": 1,
+      "templateOptions": [
+        [
+          6,
+          7
+        ],
+        [
+          8
+        ]
+      ]
+    }
+  },
+  {
+    "id": 10,
+    "content": {
+      "text": "We publicly preregister every confirmatory as well as exploratory project before any data collection following standards, like OSF preregistration challenge.",
+      "difficulty": 2
+    }
+  },
+  {
+    "id": 11,
+    "content": {
+      "title": "Preregistration",
+      "description": "We all love preregistration",
+      "options": [
+        3,
+        9,
+        10
+      ]
+    }
+  },
+  {
+    "id": 12,
+    "content": {
+      "title": "Initiating a study",
+      "description": "The first step in preparing a study is initialising it, where we get all the organisational stuff done.",
+      "contents": [
+        2,
+        11
+      ]
+    }
+  },
+  {
+    "id": 13,
+    "content": {
+      "title": "Preparing a study",
+      "description": "When we are preparing a study there are various things we want to be aware of.",
+      "contents": [
+        12
+      ]
+    }
+  },
+  {
+    "id": 14,
+    "content": {
+      "metadata": {},
+      "contents": [
+        13
+      ]
+    }
+  }
+]

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,7 +1,8 @@
 import { createStore } from 'vuex'
 
 const state = {
-
+  toFlat: template => toFlat(template),
+  toNested: template => toNested(template)
 }
 
 const mutations = {
@@ -22,3 +23,71 @@ export default createStore({
   actions,
   modules
 })
+
+/**
+ * Flatten an individual object and replace its child objects with references to whole objects.
+ * @param obj {Object} Object to parse
+ * @param flatList {Object[]} Index for use as object identifier
+ * @return {Object[]} List of parent object and its children flattened into a list
+ */
+function toFlat(obj, flatList = []) {
+
+  if(obj instanceof Object && obj !== null) {
+    const nestFields = ["contents", "options", "templateOptions"]
+    nestFields.forEach(f => {
+      if(obj[f] instanceof Array) {
+        // templateOptions is a list of lists
+        if(f === "templateOptions")
+          obj[f].forEach((t, it) => t.forEach((c, ic) => {
+            flatList = toFlat(c, flatList)
+            obj[f][it][ic] = flatList.length - 1
+          }))
+        else
+          obj[f].forEach((c, i) => {
+            // Add the child to the flattened list
+            flatList = toFlat(c, flatList)
+            // Replace child in the parent with its index in flattened list
+            obj[f][i] = flatList.length - 1
+          })
+      }
+    });
+  }
+
+  flatList.push({ id: flatList.length, content: obj })
+  return flatList
+}
+
+/**
+ * Convert a flattened tree object back into its nested form.
+ * @param flat {Object[]} Array of objects with children replaced with their ids.
+ * @return {Object}
+ */
+function toNested(flat) {
+  const nestFields = ["contents", "options", "templateOptions"]
+
+  flat.forEach(c => {
+    c = c.content
+    if(c instanceof Object) {
+      nestFields.forEach(f => {
+        if(c[f] instanceof Array) {
+          // Replace child ids with children
+          if(f === "templateOptions") {
+            c[f] = c[f].map(t => t.map(e => {
+              const value = flat.filter(x => x.id === e)
+              flat = flat.filter(x => x.id !== e)
+              return value[0].content
+            }))
+          } else {
+            c[f] = c[f].map(e => {
+              const value = flat.filter(x => x.id === e)
+              flat = flat.filter(x => x.id !== e)
+              return value[0].content
+            })
+          }
+        }
+      })
+    }
+  })
+
+  return flat[0].content
+}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -34,9 +34,9 @@ export default {
     }
   },
   computed: {
-    ...mapState(['isSidebarActive'])
-    },
-  mehtods: {
+    ...mapState(['toFlat'])
+  },
+  methods: {
     ...mapMutations([
       'toggleSidebar'
     ])

--- a/tests/unit/template.spec.js
+++ b/tests/unit/template.spec.js
@@ -1,0 +1,12 @@
+import template from '@/assets/example.json'
+import flat from '@/assets/flat.json'
+import store from '@/store'
+
+describe('Template manipulation', () => {
+  it('Flattens the template', () => {
+    expect(store.state.toFlat(template)).toMatchObject(flat)
+  })
+  it('Unflattens the template', () => {
+    expect(store.state.toNested(flat)).toMatchObject(template)
+  })
+})


### PR DESCRIPTION
Convert a nested object template structure to a flat list of objects where each parent object has its children represented by their indices in the flattened list.

Also includes methods for unflattening and tests of functionality.