### PR TITLE
Add radio buttons to Item

### DIFF
--- a/public/example.json
+++ b/public/example.json
@@ -12,6 +12,7 @@
             {
               "title": "Consultation",
               "description":  "Consultation between the team members.",
+              "options-selected": -1,
               "options": [
                 {
                   "text": "The study design is always discussed among lab members and local colleagues.",
@@ -26,6 +27,7 @@
             {
               "title": "Preregistration",
               "description": "We all love preregistration",
+              "options-selected":  -1,
               "options": [
                 "We don't do that sort of thing here.",
                 {

--- a/src/assets/example.json
+++ b/src/assets/example.json
@@ -12,6 +12,7 @@
             {
               "title": "Consultation",
               "description":  "Consultation between the team members.",
+              "options-selected": -1,
               "options": [
                 {
                   "text": "The study design is always discussed among lab members and local colleagues.",
@@ -26,6 +27,7 @@
             {
               "title": "Preregistration",
               "description": "We all love preregistration",
+              "options-selected":  -1,
               "options": [
                 "We don't do that sort of thing here.",
                 {

--- a/src/assets/flat.json
+++ b/src/assets/flat.json
@@ -18,6 +18,7 @@
     "content": {
       "title": "Consultation",
       "description": "Consultation between the team members.",
+      "options-selected": 0,
       "options": [
         0,
         1
@@ -98,6 +99,7 @@
     "content": {
       "title": "Preregistration",
       "description": "We all love preregistration",
+      "options-selected":  0,
       "options": [
         3,
         9,

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -11,9 +11,15 @@
     <p v-if="expanded">{{ itemContent.description }}</p>
     <form v-if="expanded">
       <div
-              v-for="O in itemContent.options"
+              v-for="(O, i) in itemContent.options"
               :key="O"
       >
+        <input
+                type="radio"
+                :value="i"
+                v-model="itemContent['options-selected']"
+                :name="`template-string-selection-${itemId}`"
+        />
         <TemplateString
                 :optionId="O"
                 :optionKey="O"


### PR DESCRIPTION
Each item needs to expose a radio group for each of its options so that people can choose which one they would like to use for their manual.